### PR TITLE
Mars 99 address issues with can traverse

### DIFF
--- a/src/main/java/mars/rover/MarsRover.java
+++ b/src/main/java/mars/rover/MarsRover.java
@@ -108,18 +108,14 @@ public class MarsRover extends Rover {
             int x2 = point2.getX();
             int y2 = point2.getY();
 
-            double[] slopes = {-1, -1, -1, -1, -1};
-            slopes[0] = getSlope(x1, y1, x2, y2); // traversal slope
-            slopes[1] = getSlope(x2, y2, x2 + 1, y2); //eastern slope
-            slopes[2] = getSlope(x2, y2, x2 - 1, y2); //western slope
-            slopes[3] = getSlope(x2, y2, x2, y2 + 1); //northern slope
-            slopes[4] = getSlope(x2, y2, x2, y2 - 1); //southern slope
-            for (double slope : slopes) { //check each slope to see if it greater than maxSlope
-                if (Math.abs(slope) > maxSlope) {
-                    return false;
-                }
+            double slope = getSlope(x1, y1, x2, y2); //traversal slope
+
+            if (Math.abs(slope) > maxSlope) {
+                return false;
             }
-            return true;
+            else {
+                return true;
+            }
         }
         catch(Exception e) {
             return false;


### PR DESCRIPTION
What changes were made:
Only test the slope between point1 and point2 in MarsRover.canTraverse()

What are the relevant JIRA tickets:
MARS-99

How can these changes be tested(test #?):
Use the method.

Comments:
We used to check slopes surrounding our points but that was illogical/exclusionary. 