### PR TITLE
Lat/Long Convertor built

### DIFF
--- a/src/main/java/mars/coordinate/Coordinate.java
+++ b/src/main/java/mars/coordinate/Coordinate.java
@@ -38,9 +38,9 @@ public class Coordinate {
         this.y = y;
     }
 
-    public String getUnits() {
-        return units;
-    }
+    public String getUnits() { return units; }
+
+    public void setUnits(String units){ this.units = units; };
 
     public boolean equals(Coordinate other) {
         return ((other.getX()==this.getX()) && (other.getY()==this.getY()));

--- a/src/main/java/mars/map/GeoTIFF.java
+++ b/src/main/java/mars/map/GeoTIFF.java
@@ -1,5 +1,6 @@
 package mars.map;
 
+import jj2000.j2k.codestream.CoordInfo;
 import org.geotools.coverage.grid.GridCoordinates2D;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.grid.GridGeometry2D;
@@ -156,6 +157,72 @@ public class GeoTIFF extends TerrainMap {
 
         return elevations;
     }
+
+
+
+    public Coordinate coordinatConvert(Coordinate coord){
+
+        double getEquator = gridData.getHeight() / 2;
+        double getPrimeMeridean = gridData.getWidth() / 2;
+
+        //new Coordinate placeholder
+        int xCoordInt = 0;
+        int yCoordInt = 0;
+
+        if(coord.getUnits() == "pixels") {
+
+            //get x and y coordinate
+            double xpixel = coord.getX();
+            double ypixel = coord.getY();
+
+            //declare lat/long variables
+            double latitude;
+            double longitude;
+
+            double pixelDistanceLatitude = ypixel - getEquator;
+            double pixelDistanceLongitude = xpixel - getPrimeMeridean;
+
+
+            //Viking Mosaic is 40 pixels per degree.
+            latitude = pixelDistanceLatitude / 40;
+            longitude = pixelDistanceLongitude / 40;
+
+            xCoordInt = (int) latitude;
+            yCoordInt = (int) longitude;
+
+        }
+
+        else if(coord.getUnits() == "latlong"){
+
+            //get x and y coordinate
+            double latdegree = coord.getX();
+            double longdegree = coord.getY();
+
+            //declare latitude and longitude pixel
+            double latitudepixel;
+            double longitudepixel;
+
+            //Viking Mosaic is 40 pixels per degree
+            latitudepixel = latdegree * 40;
+            longitudepixel = longdegree * 40;
+
+            double pixelDistanceLatitude = getEquator + latitudepixel;
+            double pixelDistanceLongitude = getPrimeMeridean + longitudepixel;
+
+            xCoordInt = (int) pixelDistanceLatitude;
+            yCoordInt = (int) pixelDistanceLongitude;
+
+
+        }
+        else{
+            System.out.println("Invalid Coordinate type");
+        }
+
+        Coordinate newCoord = new Coordinate(xCoordInt, yCoordInt);
+        return newCoord;
+
+    }
+
 
     /* leftover function from Route. Keeping here for now
     public void getLine(double x) throws Exception {

--- a/src/main/java/mars/out/TerminalOutput.java
+++ b/src/main/java/mars/out/TerminalOutput.java
@@ -2,6 +2,7 @@ package mars.out;
 
 import mars.algorithm.Algorithm;
 import mars.coordinate.*;
+import mars.map.GeoTIFF;
 
 import java.util.*;
 
@@ -36,10 +37,22 @@ public class TerminalOutput extends Output {
     public void writeToOutput() {
         System.out.println("\nOutput path: ");
         System.out.println("------------");
-        for (int i = 1; i <= resultList.size(); i++) {
-            int x = resultList.get(i-1).getX();
-            int y = resultList.get(i-1).getY();
-            System.out.println(i + ". (" + x + ", " + y + ")");
+        boolean convertFlag = false;
+        if(convertFlag){
+            GeoTIFF convert = new GeoTIFF();
+            for (int i = 1; i <= resultList.size(); i++) {
+                int x = resultList.get(i-1).getX();
+                int y = resultList.get(i-1).getY();
+                Coordinate outputCoordinate = convert.coordinatConvert(new Coordinate(x, y));
+                System.out.println(i + ". (" + outputCoordinate.getX() + ", " + outputCoordinate.getY() + ")");
+            }
+        }
+        else{
+            for (int i = 1; i <= resultList.size(); i++) {
+                int x = resultList.get(i - 1).getX();
+                int y = resultList.get(i - 1).getY();
+                System.out.println(i + ". (" + x + ", " + y + ")");
+            }
         }
         System.out.println("------------");
     }

--- a/src/test/java/mars/AppTest.java
+++ b/src/test/java/mars/AppTest.java
@@ -5,6 +5,7 @@ import junit.framework.TestCase;
 import junit.framework.TestSuite;
 import mars.coordinate.Coordinate;
 import mars.coordinate.GreedyCoordinate;
+import mars.map.GeoTIFF;
 import mars.rover.MarsRover;
 
 import java.util.*;
@@ -112,6 +113,19 @@ public class AppTest extends TestCase {
         assertEquals(45,neighbors.get(7).getDirection());
     }
 
+
+    public void testpixeltoLatLong() throws Exception{
+        Coordinate currentCoord = new Coordinate(11000, 5000);
+
+        GeoTIFF newMap = new GeoTIFF();
+        newMap.initMap("src/main/resources/Phobos_Viking_Mosaic_40ppd_DLRcontrol.tif");
+        Coordinate degrees = newMap.coordinatConvert(currentCoord);
+        try{
+            assertTrue(degrees.getX() != 0 && degrees.getY() != 0);
+        } catch (Exception e){
+            System.out.println(e);
+        }
+    }
 
 
 }


### PR DESCRIPTION
What changes were made:
Coordinate converter built with latlong2pixel and pixel2Latlong abilities

What are the relevant JIRA tickets:
MARS 118

How can these changes be tested(test #?):
This tool will need to be tested more once we establish a better method of converting latlong2pixel

Comments:
The coordinate converter is limited right now to only Phobos_Viking as it is calculating pixels to degrees based on the GeoTIFFs 40ppd (pixels per degree). I plan to expand this functionality soon. The converter is not super accurate when converting from Lat/Long to pixels. This is because our coordinate only supports type (INT,INT) rather than (double, double). I will try to tackle this as my next goal. 
