### PR TITLE
Allow multiple output types by separating choices by commas (and test…

### DIFF
--- a/src/main/java/mars/out/OutputFactory.java
+++ b/src/main/java/mars/out/OutputFactory.java
@@ -12,30 +12,61 @@ import java.util.List;
 public class OutputFactory {
 
     /**
-     * Returns an Output based on the name of the output class
+     * Returns Output based on the name of the output class
      * stored in the given algorithm.
+     * If an algorithm's "outputClass" contains multiple output types
+     * separated by commas, create all of them.
      *
-     * @param algorithm The Algorithm whose path will be output.
-     * @return The corresponding algorithm class
+     * @param algorithm The Algorithm whose path will be output
+     * @return The corresponding algorithm class(es)
      */
     public static Output getOutput(Algorithm algorithm) {
         String outputClass = algorithm.outputClass;
         List<? extends Coordinate> out = algorithm.getPath();
         String mapPath = algorithm.map.getMapPath();
 
-        try {
-            if (outputClass.equals("FileOutput")) {
-                return new FileOutput(algorithm);
-            } else if (outputClass.equals("MapImageOutput")) {
-                return new MapImageOutput(algorithm);
-            } else {
+        if (outputClass.contains(",")) { //multiple Output types requested
+            String[] outputs = outputClass.split(",");
+
+            try {
+                for (String output : outputs) {
+                    if (output.equals("FileOutput")) {
+                        new FileOutput(algorithm);
+                    } else if (output.equals("MapImageOutput")) {
+                        new MapImageOutput(algorithm);
+                    } else {
+                        new TerminalOutput(algorithm);
+                    }
+                }
+                return new Output() {
+                    @Override
+                    public void writeToOutput() throws IOException {
+                        //no-op to appease Java; return empty Output since all previous Outputs have already been instantiated
+                    }
+                };
+            } catch (IOException ex) {
+                //If something weird happened with FileOutput, default to TerminalOutput
+                ex.printStackTrace();
                 return new TerminalOutput(algorithm);
             }
-        } catch (IOException ex) {
-            //If something weird happened with FileOutput, default to TerminalOutput
-            ex.printStackTrace();
-            return new TerminalOutput(algorithm);
         }
+        else { //only one Output type requested
+            try {
+                if (outputClass.equals("FileOutput")) {
+                    return new FileOutput(algorithm);
+                } else if (outputClass.equals("MapImageOutput")) {
+                    return new MapImageOutput(algorithm);
+                } else {
+                    return new TerminalOutput(algorithm);
+                }
+            } catch (IOException ex) {
+                //If something weird happened with FileOutput, default to TerminalOutput
+                ex.printStackTrace();
+                return new TerminalOutput(algorithm);
+            }
+        }
+
+
     }
 
 }

--- a/src/main/java/mars/ui/TerminalInterface.java
+++ b/src/main/java/mars/ui/TerminalInterface.java
@@ -42,7 +42,6 @@ public class TerminalInterface extends UserInterface {
         System.out.println("**==================================================**");
         System.out.println("*  Welcome to the Martian Autonomous Routing System. *");
         System.out.println("**==================================================**\n");
-        //TODO: Print basic description of prompts to follow?
 
         promptForMap();
         promptForSlope();
@@ -288,21 +287,24 @@ public class TerminalInterface extends UserInterface {
         String outputDir = "src/main/java/mars/out/";
         Map<Integer, String> outputs = findOutputs(outputDir);
 
-        System.out.println("\nLast question, please choose your output type:\n");
+        System.out.println("\nLast question, please choose your output type (separate multiple choices with commas ','):\n");
         for (Integer index : outputs.keySet()) {
             System.out.println("("+index+") " + outputs.get(index));
         }
         System.out.println(); //New line
 
         Scanner scan = new Scanner(System.in);
+
         while (true) {
             try {
-                int outputNum = new Integer(scan.next());
-                String outputChoice = outputs.get(outputNum);
-                if (outputChoice != null) {
-                    outputClass = outputChoice;
+                String requestedOutputs = scan.nextLine();
+                Boolean requestIsValid = checkOutputRequest(requestedOutputs, outputs);
+
+                if (requestIsValid) {
+                    outputClass = getOutputTypesFromRequest(requestedOutputs, outputs);
                     break;
-                } else {
+                }
+                else {
                     throw new Exception("Please only select from the given options.");
                 }
             } catch (Exception ex) {
@@ -311,6 +313,54 @@ public class TerminalInterface extends UserInterface {
         }
     }
 
+    /**
+     * Helper method to check if the user requested Output types in the proper format.
+     * E.g., "2" or "1,3" or "1,  2,3"
+     *
+     * @param in The user's input
+     * @return Returns true if the input is formatted correctly, else false
+     */
+    public boolean checkOutputRequest(String in, Map<Integer, String> outputs) {
+        String[] choices = in.split(",");
+
+        if (choices.length > outputs.size()) { //if user requested more Output types than are available
+            return false;
+        }
+        else { //user requested a proper amount of Output types
+            for (String choice : choices) {
+                try {
+                    int outputNum = Integer.parseInt(choice.trim());
+                    if (!(outputNum <= outputs.size() && outputNum > 0)) { //if user's requested number isn't an option
+                        return false;
+                    }
+                } catch (NumberFormatException ex) { //one of the user's choices wasn't a number
+                    return false;
+                }
+            }
+        }
+
+        return true; //user's request passed all the checks
+    }
+
+    /**
+     * Helper method to return a well-formatted String representation of
+     * the requested Output type(s). Assumes that the user's input has
+     * already been checked for correctness (by checkOutputRequest).
+     *
+     * @param in The user's well-formatted input
+     * @return A well-formatted String representation of the requested Output type(s).
+     */
+    public String getOutputTypesFromRequest(String in, Map<Integer, String> outputs) {
+        String outputTypes = "";
+        String[] choices = in.split(",");
+
+        for (String choice : choices) {
+            int key = Integer.parseInt(choice.trim());
+            outputTypes = outputTypes + outputs.get(key) + ",";
+        }
+
+        return outputTypes.substring(0, outputTypes.length()-1); //drop the trailing comma from the output string
+    }
 
 
     //----Resource scanning methods-------------------------------------------------------------------------------------

--- a/src/main/java/mars/views/MapFrame.java
+++ b/src/main/java/mars/views/MapFrame.java
@@ -69,7 +69,7 @@ public class MapFrame extends JFrame {
             setPreferredSize(new Dimension(frameWidth, frameHeight));
             getViewport().add(imagePanel); //Put the pane with the map image in this scroll pane
 
-            int firstX = path.get(0).getX() ;
+            int firstX = path.get(0).getX();
             int firstY = path.get(0).getY(); //Note that all the Y's in "path" have been altered by MapPanel.convertPathXYtoJavaXY()
 
             //Center the view position as much as possible
@@ -84,6 +84,8 @@ public class MapFrame extends JFrame {
                 firstY = firstY - frameHeight/2;
 
             getViewport().setViewPosition(new Point(firstX, firstY));
+            //Put the altered path back to normal to avoid unwanted changes to the algorithm's path
+            MapPanel.convertJavaXYtoPathXY(path, backgroundImage);
         }
     }
 

--- a/src/main/java/mars/views/MapPanel.java
+++ b/src/main/java/mars/views/MapPanel.java
@@ -69,6 +69,19 @@ public class MapPanel extends JPanel {
     }
 
     /**
+     * Reverse the disparity between Geotools' coordinate system and the one
+     * used by Java images. In Java images, X grows normally but Y grows downward.
+     * So convert the Java (X,Y)'s in the path back to the corresponding original (X,Y)'s.
+     */
+    public static void convertJavaXYtoPathXY(java.util.List<? extends Coordinate> path, BufferedImage mapBackgroundImage) {
+        for (Coordinate c : path) {
+            int javaY = c.getY();
+            int y = mapBackgroundImage.getHeight() - javaY;
+            c.setY(y);
+        }
+    }
+
+    /**
      * Given an image of a map and a path of Coordinates,
      * draw that path on the map as a red line.
      *

--- a/src/test/java/mars/OutputTest.java
+++ b/src/test/java/mars/OutputTest.java
@@ -7,10 +7,12 @@ import mars.coordinate.Coordinate;
 import mars.out.FileOutput;
 import mars.out.MapImageOutput;
 import mars.out.TerminalOutput;
+import mars.ui.TerminalInterface;
 
 import java.io.File;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.Scanner;
 
 public class OutputTest extends TestCase{
@@ -56,6 +58,31 @@ public class OutputTest extends TestCase{
         String testString = testScan.nextLine();
         testScan.close();
         assertEquals(testString, "1059039900,1023360986");
+    }
+
+    public void testMultipleOutputRequestFormatting() throws Exception {
+        TerminalInterface ti = new TerminalInterface();
+        String outputDir = "src/main/java/mars/out/";
+        Map<Integer, String> outputs = ti.findOutputs(outputDir);
+        String request = "";
+
+        request = "1";
+        Boolean requestIsValid = ti.checkOutputRequest(request, outputs);
+        assertTrue(requestIsValid);
+        assertEquals("FileOutput", ti.getOutputTypesFromRequest(request, outputs));
+
+        request = "1,2,  3";
+        requestIsValid = ti.checkOutputRequest(request, outputs);
+        assertTrue(requestIsValid);
+        assertEquals("FileOutput,MapImageOutput,TerminalOutput", ti.getOutputTypesFromRequest(request, outputs));
+
+        request = "1, stupid";
+        requestIsValid = ti.checkOutputRequest(request, outputs);
+        assertFalse(requestIsValid);
+
+        request = "stupid";
+        requestIsValid = ti.checkOutputRequest(request, outputs);
+        assertFalse(requestIsValid);
     }
 
     /*


### PR DESCRIPTION
What changes were made:
Allow users to select multiple output types in TerminalInterface through comma-separated values.

What are the relevant JIRA tickets:
MARS-131

How can these changes be tested(test #?):
I added tests for the helper methods that test the formatting of the new TerminalInterface logic.
But the best way to test this is to just run the program and request multiple output types.

Comments:
